### PR TITLE
Fix broken collection and NFT image links

### DIFF
--- a/labs/metaplex-umi/sample-nft-collection-offchain-data.json
+++ b/labs/metaplex-umi/sample-nft-collection-offchain-data.json
@@ -1,5 +1,5 @@
 {
   "name": "Test Collection",
   "description": "Description for test collection",
-  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/collection.png"
+  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/metaplex-umi/collection.png"
 }

--- a/labs/metaplex-umi/sample-nft-offchain-data.json
+++ b/labs/metaplex-umi/sample-nft-offchain-data.json
@@ -1,5 +1,5 @@
 {
   "name": "Test NFT",
   "description": "Description for test NFT",
-  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/nft.png"
+  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/metaplex-umi/nft.png"
 }

--- a/labs/sample-nft-collection-offchain-data.json
+++ b/labs/sample-nft-collection-offchain-data.json
@@ -1,5 +1,5 @@
 {
   "name": "TestCollectionNFT",
   "description": "Test Description Collection",
-  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/collection.png"
+  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/metaplex-umi/collection.png"
 }

--- a/labs/sample-nft-offchain-data.json
+++ b/labs/sample-nft-offchain-data.json
@@ -1,5 +1,5 @@
 {
   "name": "Test NFT",
   "description": "Test NFT",
-  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/nft.png"
+  "image": "https://raw.githubusercontent.com/solana-developers/professional-education/main/labs/metaplex-umi/nft.png"
 }


### PR DESCRIPTION
Seems like two images in this repo were moved to different folders. As a result, their raw GitHub links were broken. I fixed the links to point to the new locations of those images.

PS: Came from the Developer Bootcamp 2024 videos on Solana's official YouTube channel. That content is very helpful - thank you guys!